### PR TITLE
feat: add endpoints

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,16 +1,119 @@
 import express, { Request, Response, Router } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
-import GeneralModel from "src/models";
+import { PrismaClient } from "@prisma/client";
+// import GeneralModel from "src/models";
 
-// Router
+const prisma = new PrismaClient();
 const router: Router = express.Router();
 
-router.get("/places", async (req: Request, res: Response) => {
-  const data = GeneralModel.getInitialData();
+// --! Places andpoints
 
-  res.send({
-    data,
-  });
+//Retrieve the Place interfaced object
+router.get("/places", async (req: Request, res: Response) => {
+  try {
+    const places = await prisma.places.findMany({
+      include: {
+        experiences: true,
+        images: true,
+      },
+    });
+    res.json(places);
+  } catch (error) {
+    res.status(500).json({ error });
+  }
 });
+
+//Add a new place
+router.post("/places", async (req: Request, res: Response) => {
+  try {
+    const placeData = req.body;
+    const newPlace = await prisma.places.create({
+      data: placeData,
+    });
+    res.status(201).json(newPlace);
+  } catch (error) {
+    res.status(400).json({ error });
+  }
+});
+
+//Update details of specific place
+router.patch("/places/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const updateData = req.body;
+    const updatedPlace = await prisma.places.update({
+      where: { id: Number(id) },
+      data: updateData,
+    });
+    res.json({ updatedPlace });
+  } catch (error) {
+    res.status(400).json({ error });
+  }
+});
+
+//Remove place by its ID
+router.delete("/places/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    await prisma.places.delete({
+      where: { id: Number(id) },
+    });
+    res.status(204).send();
+  } catch (error) {
+    res.status(400).json({ error });
+  }
+});
+
+// --! Experiences endpoints
+
+//Retrieve all experiences related to a specific place
+router.post("/places/:id/experiences", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const experienceData = req.body;
+    const newExperience = await prisma.experiences.create({
+      data: {
+        ...experienceData,
+        place_id: Number(id),
+      },
+    });
+    res.status(201).json(newExperience);
+  } catch (error) {
+    res.status(400).json({ error });
+  }
+});
+
+//Update details of a specific experience
+router.patch(
+  "/places/:id/experiences/:expId",
+  async (req: Request, res: Response) => {
+    try {
+      const expID = req.params;
+      const updateData = req.body;
+      const updatedExperience = await prisma.experiences.update({
+        where: { id: Number(expID) },
+        data: updateData,
+      });
+      res.json(updatedExperience);
+    } catch (error) {
+      res.status(400).json({ error });
+    }
+  }
+);
+
+//Remove experience by its ID
+router.delete(
+  "/places/:id/experiences/:expId",
+  async (req: Request, res: Response) => {
+    try {
+      const expID = req.params;
+      await prisma.experiences.delete({
+        where: { id: Number(expID) },
+      });
+      res.status(204).send();
+    } catch (error) {
+      res.status(400).json({ error });
+    }
+  }
+);
 
 export default router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,6 +46,7 @@ router.patch("/places/:id", async (req: Request, res: Response) => {
     });
     res.json({ updatedPlace });
   } catch (error) {
+    console.error(error);
     res.status(400).json({ error });
   }
 });
@@ -78,6 +79,7 @@ router.post("/places/:id/experiences", async (req: Request, res: Response) => {
     });
     res.status(201).json(newExperience);
   } catch (error) {
+    console.error(error);
     res.status(400).json({ error });
   }
 });
@@ -87,7 +89,7 @@ router.patch(
   "/places/:id/experiences/:expId",
   async (req: Request, res: Response) => {
     try {
-      const expID = req.params;
+      const { expID } = req.params;
       const updateData = req.body;
       const updatedExperience = await prisma.experiences.update({
         where: { id: Number(expID) },
@@ -95,6 +97,7 @@ router.patch(
       });
       res.json(updatedExperience);
     } catch (error) {
+      console.error(error);
       res.status(400).json({ error });
     }
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,7 @@ router.get("/places", async (req: Request, res: Response) => {
     });
     res.json(places);
   } catch (error) {
+    console.error(error);
     res.status(500).json({ error });
   }
 });
@@ -31,6 +32,7 @@ router.post("/places", async (req: Request, res: Response) => {
     });
     res.status(201).json(newPlace);
   } catch (error) {
+    console.error(error);
     res.status(400).json({ error });
   }
 });
@@ -60,6 +62,7 @@ router.delete("/places/:id", async (req: Request, res: Response) => {
     });
     res.status(204).send();
   } catch (error) {
+    console.error(error);
     res.status(400).json({ error });
   }
 });
@@ -71,6 +74,7 @@ router.post("/places/:id/experiences", async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const experienceData = req.body;
+    console.log(experienceData);
     const newExperience = await prisma.experiences.create({
       data: {
         ...experienceData,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,8 @@ import cors, { CorsOptions } from "cors";
 // Environment variables
 import "dotenv/config";
 
+import router from "./router";
+
 const app = express();
 const port = process.env.PORT || 3000;
 
@@ -17,6 +19,8 @@ const corsOptions: CorsOptions = {
 };
 app.use(cors(corsOptions));
 app.use(morgan("dev"));
+
+app.use("/", router);
 
 app.get("/", (req: Request, res: Response) => {
   res.send("Express + TypeScript Server Working!");


### PR DESCRIPTION
Added these endpoints.

<Places>
- GET /places : Retrieves the Place interfaced object, no just ‘Places table rows’
- POST /places : Add a new place to the database
- PATCH /places/:id : Update the details of a specific place.
- DELETE /places/:id : Remove a place by its ID.


<Experiences>
- POST /places/:id/experiences : Add a new experience for a specific place.
- PATCH /places/:id/experiences/:expId Update details of a specific experience by its ID.
- DELETE /places/:id/experiences/:expId : Remove an experience by its ID.
